### PR TITLE
Fixes closing Zooms new landing page (Issue #5)

### DIFF
--- a/Modules/ZoomInExtension/Resources/script.js
+++ b/Modules/ZoomInExtension/Resources/script.js
@@ -2,13 +2,13 @@
 window.addEventListener("load", function(event) {
     // Get the URL from Zoom’s page
     let url;
-    let oldZoomPageElement = document.getElementById('scheme_url');
-    if (oldZoomPageElement) {
-        url = oldZoomPageElement['value'];
+    const linkElement = document.getElementById('scheme_url');
+    if (linkElement) {
+        url = linkElement['value'];
     } else {
-        const selectors = document.querySelectorAll('[launch]');
-        if (selectors.length > 0) {
-            url = selectors[0].href;
+        const anchorElement = document.querySelector('a[launch]');
+        if (anchorElement) {
+            url = anchorElement.href;
         }
     }
     

--- a/Modules/ZoomInExtension/Resources/script.js
+++ b/Modules/ZoomInExtension/Resources/script.js
@@ -1,8 +1,21 @@
 // Wait for the page to load
-document.addEventListener("DOMContentLoaded", function(event) {
+window.addEventListener("load", function(event) {
     // Get the URL from Zoom’s page
-    const url = document.getElementById('scheme_url')['value'];
-
+    let url;
+    let oldZoomPageElement = document.getElementById('scheme_url');
+    if (oldZoomPageElement) {
+        url = oldZoomPageElement['value'];
+    } else {
+        const selectors = document.querySelectorAll('[launch]');
+        if (selectors.length > 0) {
+            url = selectors[0].href;
+        }
+    }
+    
+    if (!url) {
+        return;
+    }
+    
     // Tell the native extension about the URL
     safari.extension.dispatchMessage('open', { url: url });
 });


### PR DESCRIPTION
Allow both of Zooms landing page styles by first trying the old one and afterwards the new one. Resolves #5 